### PR TITLE
Fix async webhook sending in notifyAdmins

### DIFF
--- a/src/main/java/us/ajg0702/antixray/Main.java
+++ b/src/main/java/us/ajg0702/antixray/Main.java
@@ -270,7 +270,9 @@ public class Main extends JavaPlugin {
 									"ORE:" + bk,
 									"DELAY:" + (delay/60000)
 							);
-							WebhookSender.send(getLogger(), webhookUrl, webhookMessage);
+							Bukkit.getScheduler().runTaskAsynchronously(Main.this, () -> {
+								WebhookSender.send(getLogger(), webhookUrl, webhookMessage);
+							});
 						}
 					}
 				}, (long) (Math.floor((Math.random()*2) * 20)));


### PR DESCRIPTION
Right now, the webhook call happens on the main thread, switch it to run async.